### PR TITLE
Fix CI workflow and add test coverage

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestVersionCommand(t *testing.T) {
+	// Simple test to verify that the version command exists
+	if versionCmd == nil {
+		t.Fatal("versionCmd is nil")
+	}
+
+	if versionCmd.Use != "version" {
+		t.Errorf("expected command Use to be 'version', got %s", versionCmd.Use)
+	}
+}
+
+func TestRootCommand(t *testing.T) {
+	// Simple test to verify that the root command exists
+	if rootCmd == nil {
+		t.Fatal("rootCmd is nil")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jishnusygal/terraform-docs-extended
 
-go 1.16
+go 1.18
 
 require (
 	github.com/fatih/color v1.13.0

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -7,10 +7,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/jishnusygal/terraform-docs-extended/pkg/formatter"
 	"github.com/jishnusygal/terraform-docs-extended/pkg/terraform"
 )
+
+// execCommand is a variable to allow mocking in tests
+var execCommand = exec.Command
 
 // ProcessRecursively handles recursive directory traversal
 func ProcessRecursively(root string, format string, outputFile string, moduleName string, moduleSource string, quiet bool) error {
@@ -140,6 +144,23 @@ func IsTerraformDocsInstalled() bool {
 		return false
 	}
 	return true
+}
+
+// GetTerraformDocsVersion returns the version of terraform-docs
+func GetTerraformDocsVersion() string {
+	cmd := execCommand("terraform-docs", "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	
+	// Parse version from output like "terraform-docs v0.16.0"
+	versionOutput := string(output)
+	parts := strings.Fields(versionOutput)
+	if len(parts) >= 2 {
+		return parts[1] // Return just the version part
+	}
+	return ""
 }
 
 // MergeVariables combines variable information from terraform-docs with direct parsing

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1,0 +1,38 @@
+package processor
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestIsTerraformDocsInstalled(t *testing.T) {
+	// Skip this test if we're in CI environment since it depends on external program
+	if _, err := exec.LookPath("terraform-docs"); err != nil {
+		t.Skip("terraform-docs not installed, skipping test")
+	}
+	
+	// The actual function just checks if terraform-docs is installed
+	result := IsTerraformDocsInstalled()
+	if !result {
+		t.Error("IsTerraformDocsInstalled returned false but terraform-docs is installed")
+	}
+}
+
+// Simple unit test that doesn't depend on external commands
+func TestGetTerraformDocsVersion(t *testing.T) {
+	// Mock executing command by replacing function
+	origExecCommand := execCommand
+	defer func() { execCommand = origExecCommand }()
+	
+	// Mock version output
+	execCommand = func(command string, args ...string) *exec.Cmd {
+		return exec.Command("echo", "terraform-docs v0.16.0")
+	}
+	
+	version := GetTerraformDocsVersion()
+	expected := "v0.16.0"
+	
+	if version != expected {
+		t.Errorf("Expected version %s, got %s", expected, version)
+	}
+}

--- a/pkg/terraform/parser_test.go
+++ b/pkg/terraform/parser_test.go
@@ -1,0 +1,24 @@
+package terraform
+
+import (
+	"testing"
+)
+
+func TestVariableStructure(t *testing.T) {
+	// Simple test to ensure our Variable struct exists and has expected fields
+	v := Variable{
+		Name:        "test_var",
+		Type:        "string",
+		Description: "Test variable",
+		Default:     "default_value",
+		Required:    true,
+	}
+	
+	if v.Name != "test_var" {
+		t.Errorf("Expected variable name to be 'test_var', got %s", v.Name)
+	}
+	
+	if v.Type != "string" {
+		t.Errorf("Expected variable type to be 'string', got %s", v.Type)
+	}
+}


### PR DESCRIPTION
This PR fixes the failing CI workflow by:

1. Updating the Go version in go.mod from 1.16 to 1.18 to match the CI workflow
2. Adding basic test files for all packages:
   - cmd/root_test.go - Tests for the root and version commands
   - pkg/processor/processor_test.go - Tests for the processor package
   - pkg/terraform/parser_test.go - Tests for the terraform package
3. Adding the missing GetTerraformDocsVersion function and execCommand variable to the processor package for testing

These changes should allow the CI workflow to complete successfully without errors.
