### PR TITLE
Fix formatTypeForUsage function to match test expectations

### DIFF
--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -285,16 +285,16 @@ func formatTypeForUsage(typeStr string) string {
 	}
 	
 	// For lists, maps, and sets with complex element types
-	for _, prefix := range []string{"list(", "map(", "set("} {
-		if strings.HasPrefix(typeStr, prefix) && strings.Contains(typeStr, "object(") {
-			elementStart := len(prefix)
-			elementEnd := len(typeStr) - 1
-			element := typeStr[elementStart:elementEnd]
-			
-			if len(element) > 30 {
-				return prefix + "...)"
-			}
-		}
+	if strings.HasPrefix(typeStr, "list(") && strings.Contains(typeStr, "object(") {
+		return "list(...)"
+	}
+	
+	if strings.HasPrefix(typeStr, "map(") && strings.Contains(typeStr, "object(") {
+		return "map(...)"
+	}
+	
+	if strings.HasPrefix(typeStr, "set(") && strings.Contains(typeStr, "object(") {
+		return "set(...)"
 	}
 	
 	return typeStr


### PR DESCRIPTION
## Problem
The GitHub Actions CI workflow is failing in the test phase because the `formatTypeForUsage` function in `pkg/formatter/formatter.go` doesn't correctly handle list, map, and set types in the way that the tests expect.

## Solution
This PR modifies the `formatTypeForUsage` function to properly handle these cases:

1. For `list(object(...))`, it now returns "list(...)" as expected by the tests
2. For `map(object(...))`, it now returns "map(...)" 
3. For `set(object(...))`, it now returns "set(...)"

This change makes the function implementation match the expectations in the test cases and should fix the failing CI job.

## Testing
The modified function should pass all the test cases defined in `formatter_test.go`, including those for complex types.